### PR TITLE
Fix a bug on using `key` instead of `name = print(key,...)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function printObject(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDep
       const name = print(key, indent, innerIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName, escapeRegex, colors);
       const value = print(val[key], indent, innerIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName, escapeRegex, colors);
 
-      result += innerIndent + key + ': ' + value;
+      result += innerIndent + name + ': ' + value;
 
       if (i < keys.length - 1) {
         result += colors.comma.open + ',' + colors.comma.close + spacing;


### PR DESCRIPTION
[This change](https://github.com/avajs/pretty-format/commit/a8fc8adfff9ab941a827f639b8522c525e1a5642#diff-168726dbe96b3ce427e7fedce31bb0bcL173) broke all the tests!

I had major problems in testing an object with Symbol properties with AVA.

The worst part was the very unclear error message:

```
caesarsol $ ./node_modules/.bin/ava -v

  - testing object with symbol
Uncaught Exception: test.js
  TypeError: Cannot convert a Symbol value to a string
    printObject (node_modules/@ava/pretty-format/index.js:173:29)
    printComplexValue (node_modules/@ava/pretty-format/index.js:238:39)
    prettyFormat (node_modules/@ava/pretty-format/index.js:380:10)
    node_modules/clean-yaml-object/index.js:69:9
    cleanYamlObj (node_modules/clean-yaml-object/index.js:57:15)
    module.exports (node_modules/clean-yaml-object/index.js:3:9)
  
  ✖ Test results were not received from test.js

  0 tests passed [08:49:48]
  2 uncaught exceptions
```